### PR TITLE
Show better error message on failure to convert Excels to CSVs

### DIFF
--- a/src/build-csv.js
+++ b/src/build-csv.js
@@ -34,8 +34,10 @@ const excel2csv = async (excelPath) => {
       const excelPath = file.path;
       const csvPath = join(dirname(excelPath), `${basename(excelPath, ".xlsx")}.csv`);
 
-      const csv = await excel2csv(excelPath);
-      promises.push(writeFile(csvPath, csv));
+      promises.push((async () => {
+        const csv = await excel2csv(excelPath);
+        await writeFile(csvPath, csv);
+      })());
     }
   }
 

--- a/src/build-csv.js
+++ b/src/build-csv.js
@@ -35,8 +35,15 @@ const excel2csv = async (excelPath) => {
       const csvPath = join(dirname(excelPath), `${basename(excelPath, ".xlsx")}.csv`);
 
       promises.push((async () => {
-        const csv = await excel2csv(excelPath);
-        await writeFile(csvPath, csv);
+        try {
+          const csv = await excel2csv(excelPath);
+          await writeFile(csvPath, csv);
+        } catch (err) {
+          if (err.message === "FILE_ENDED") {
+            console.error(`Error: Excel ファイル ${excelPath} を読み取れませんでした。データが空になっているか、Excel ファイルが破損している可能性があります。`);
+          }
+          throw err;
+        }
       })());
     }
   }


### PR DESCRIPTION
Excel ファイルが破損している、空である、その他の理由により、Excel ファイルの読み込みに失敗した場合のエラーメッセージを改善しました。
また、どの Excel ファイルの読み込みに失敗したのかを表示するようにしました。

Closes #103