### PR TITLE
ブランチプロテクションを有効化する為に、exit code を GitHub Actionに追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
             git commit -m "Update README"; \
             git push; \
           fi
+          exit $? # need for passing GitHub Branch Protection
 
       - uses: actions/upload-artifact@v3
         if: github.ref == 'refs/heads/main'
@@ -125,6 +126,7 @@ jobs:
             git commit --message="CSV をアップデート"
             git push origin "${GITHUB_HEAD_REF}"
           fi
+          exit $? # need for passing GitHub Branch Protection
 
   backup:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
GitHub のブランチプロテクションルール` Require status checks to pass before merging` を有効化時に、GitHub Action の build と pushcsv job に exit code を指定しないと、Action が成功してもPullrequest の画面ではテストがパスしなかったため、前のコマンドの exit code に合わせて、exit code を返すように修正。