### PR TITLE
壊れたファイルを追加時に README から 都市計画基礎調査情 が削除されてしまう問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,27 @@ jobs:
       - run: npm run build-csv
         continue-on-error: true
         id: build-step
+
+      - name: Comment to PR if build fails
+        id: comment-build-error
+        if: steps.build-step.outcome == 'failure'
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issue_number = context.issue.number;
+            const message = `## エラー：Excel の変換に失敗しました\n アップロードした Excel ファイルにデータが含まれていないか、壊れている可能性があります。再度ご確認ください。`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: message
+            });
+ 
+      - name: Exit with failure
+        if: steps.build-step.outcome == 'failure'
+        run: exit 1
+
       - run: npm run build-location-data
       - run: npm run build-standard-data
       - run: npm run build-api
@@ -60,26 +81,6 @@ jobs:
         with:
           name: build
           path: build
-                    
-      - name: Comment to PR if build fails
-        id: comment-build-error
-        if: steps.build-step.outcome == 'failure'
-        uses: actions/github-script@v5
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const issue_number = context.issue.number;
-            const message = `## エラー：Excel の変換に失敗しました\n アップロードした Excel ファイルにデータが含まれていないか、壊れている可能性があります。再度ご確認ください。`;
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              body: message
-            });
- 
-      - name: Exit with failure
-        if: steps.build-step.outcome == 'failure'
-        run: exit 1
 
   comment-diff:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
壊れたExcelを追加時に、都市計画基礎調査情報(0085) の項目が README から削除される現象を修正しました。[（例：#187）](https://github.com/takamatsu-city/opendata/pull/187/files)

原因は、以下の箇所で `city_planning_basic_survey_information` のみ CSV の build が必要な事でした。
https://github.com/takamatsu-city/opendata/blob/main/src/build-readme.js#L43-L44

なので、README 生成処理の前に エラーで失敗するように修正しました。