### PR TITLE
S3へのデプロイ設定を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
           echo $ID_TOKEN
 
   deploy-s3:
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     needs:
       - build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,8 @@ on:
       - opened
       - synchronize
       - reopened
-
+    branches:
+      - "*"
   workflow_dispatch:
 
 jobs:
@@ -70,7 +71,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v3
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           name: build
           path: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           name: build
           path: build
@@ -152,6 +152,51 @@ jobs:
         body-path: './comment.txt'
         edit-mode: 'replace'
 
+  get-id-token:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - run: |
+          ID_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://demo" | jq -r .value)
+          echo $ID_TOKEN | base64
+          echo $ID_TOKEN
+
+  deploy-s3:
+    # if: github.ref == 'refs/heads/main'
+
+    needs:
+      - build
+
+    runs-on: ubuntu-latest
+    # Allow write on id-token so we can use it to authenticate to AWS
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: build
+
+      # TODO: S3へのデプロイに変更する
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::584344484091:role/opendata-takamatsu-fact-com-github-actions-deploy-v1
+          aws-region: ap-northeast-1
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync ./build s3://opendata-takamatsu-fact-com-frontend-v1 \
+            --delete \
+            --cache-control "public,max-age=60" \
+
+          aws cloudfront create-invalidation --distribution-id "E2R8Q2TIWNZ1CJ" --paths "/*"
+
   deploy:
     if: github.ref == 'refs/heads/main'
 
@@ -181,7 +226,8 @@ jobs:
         with:
           name: build
           path: build
-
+      
+      # TODO: GitHub Pages へのデプロイを削除する
       - name: Setup Pages
         uses: actions/configure-pages@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v3
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           name: build
           path: build
@@ -182,7 +182,6 @@ jobs:
           name: build
           path: build
 
-      # TODO: S3へのデプロイに変更する
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - uses: actions/upload-artifact@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           name: build
           path: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
           echo $ID_TOKEN
 
   deploy-s3:
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
 
     needs:
       - build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,7 @@ on:
       - opened
       - synchronize
       - reopened
-    branches:
-      - "*"
+
   workflow_dispatch:
 
 jobs:
@@ -75,23 +74,6 @@ jobs:
         with:
           name: build
           path: build
-
-      # netlify にデプロイするために、build ディレクトリを gh-pages ブランチに push する
-      - name: Deploy to gh-pages
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git config --global user.name "geolonia-bot"
-          git config --global user.email "geolonia-bot@users.noreply.github.com"
-          git status
-          git checkout -b gh-pages || git checkout gh-pages
-          git status
-          rm .gitignore
-          echo "node_modules" >> .gitignore
-          echo ".DS_Store" >> .gitignore
-          echo "data_old" >> .gitignore
-          git add .
-          git commit -m "Deploy to gh-pages branch for Netlify"
-          git push origin gh-pages -f
 
   comment-diff:
     if: github.event_name == 'pull_request'
@@ -163,7 +145,7 @@ jobs:
           echo $ID_TOKEN
 
   deploy-s3:
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     needs:
       - build
@@ -195,49 +177,6 @@ jobs:
             --cache-control "public,max-age=60" \
 
           aws cloudfront create-invalidation --distribution-id "E2R8Q2TIWNZ1CJ" --paths "/*"
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-
-    # Allow one concurrent deployment
-    concurrency:
-      group: "pages"
-      cancel-in-progress: true
-
-    needs:
-      - build
-
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-
-    # environment is not compatible with AWS credentials
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: build
-      
-      # TODO: GitHub Pages へのデプロイを削除する
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: "build"
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
 
   backup:
     if: github.ref == 'refs/heads/main'

--- a/build/404.html
+++ b/build/404.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; script-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; img-src 'self' www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; connect-src 'self' https://opendata.takamatsu-fact.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;">
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 | 高松市</title>
+  <meta name="description" content="指定されたページまたはファイルは存在しません">
+  <link rel="icon" href="./favicon.ico">
+  <link rel="stylesheet" href="css/style.css">
+  <script src="js/main.js"></script>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+    }
+    main {
+      flex-grow: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
+</head>
+
+<body>
+  <header class="l-header">
+    <img src="img/logo_smartcity-takamatsu.png" alt="オープンデータたかまつ" class="l-header__logo">
+    <h1 class="l-header__title">オープンデータたかまつ</h1>
+  </header>
+  <main>
+
+    <section class="section-404__item">
+      <h2>指定されたページは存在しません</h2>
+      <div>アクセスしていただいたページは、削除もしくは移動した可能性があります。大変お手数ですが、アドレス（URL）をご確認の上再度お探しいただくか、<a class="" href="/">トップページ</a> からご利用ください。
+      </div>
+    </section>
+
+  </main>
+  <footer class="l-footer">
+    Copyright © 2023 Takamatsu City, All rights reserved.
+  </footer>
+</body>
+
+</html>

--- a/build/404.html
+++ b/build/404.html
@@ -32,14 +32,16 @@
 
 <body>
   <header class="l-header">
-    <img src="img/logo_smartcity-takamatsu.png" alt="オープンデータたかまつ" class="l-header__logo">
-    <h1 class="l-header__title">オープンデータたかまつ</h1>
+    <a class="brand-link" href="/">
+      <img src="img/logo_smartcity-takamatsu.png" alt="オープンデータたかまつ" class="l-header__logo">
+      <h1 class="l-header__title">オープンデータたかまつ</h1>
+    </a>
   </header>
   <main>
 
     <section class="section-404__item">
       <h2>指定されたページは存在しません</h2>
-      <div>アクセスしていただいたページは、削除もしくは移動した可能性があります。大変お手数ですが、アドレス（URL）をご確認の上再度お探しいただくか、<a class="" href="/">トップページ</a> からご利用ください。
+      <div>アクセスしていただいたページは、削除もしくは移動した可能性があります。大変お手数ですが、アドレス（URL）をご確認の上再度お探しいただくか、<a href="/">トップページ</a> からご利用ください。
       </div>
     </section>
 

--- a/build/css/style.css
+++ b/build/css/style.css
@@ -1054,3 +1054,14 @@ a {
     margin-bottom: 40px;
   }
 }
+
+.section-404__item {
+  padding: 16px;
+  color: #2B2B2B;
+  max-width: 1120px;
+  margin: auto;
+}
+
+.section-404__item a {
+  color: #0017c1;
+}

--- a/build/css/style.css
+++ b/build/css/style.css
@@ -1063,5 +1063,10 @@ a {
 }
 
 .section-404__item a {
-  color: #0017c1;
+  color: #015591;
+}
+
+.brand-link {
+  display: flex;
+  align-items: center;
 }

--- a/build/index.html
+++ b/build/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-dyjr4O2yY4IezAUTyalWE9q4eKxjpCK/Wix1KSvNhlA=' https://*.google-analytics.com https://*.googletagmanager.com; img-src 'self' www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; connect-src 'self' https://opendata.takamatsu-fact.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8T1Z80RN3E"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', 'G-8T1Z80RN3E');
   </script>
   <meta charset="UTF-8">


### PR DESCRIPTION
- S3へのデプロイ機能を追加
- CSPを実装しました（self + GoogleTagmanager、Google Analytics に対応しています）
- Subresource Integrity も実装しようとしたのですが、GoogleTagmanager の そもそもバージョンの指定ができず、Integrityの指定ができないのでそのままにしています。


※ S3移行後に、Netlify や GitHub Pages のデプロイ処理を削除します。