### PR TITLE
INSTRUCTION.md にデータ名称変更・削除の手順を追記

### DIFF
--- a/INSTRUCTION.md
+++ b/INSTRUCTION.md
@@ -65,3 +65,58 @@
 
 <img width="1120" alt="スクリーンショット 2023-05-18 18 12 54" src="https://github.com/takamatsu-city/opendata/assets/8760841/f468a815-3dc4-4dec-af83-bc5064c51bf9">
 
+## データ名称の変更方法
+
+データの表示名を変更したい場合は、以下の2つのファイルを編集して下さい。
+
+### 1. config.yml を編集
+
+- https://github.com/takamatsu-city/opendata/tree/main/data に移動し、名称を変更したいデータのディレクトリを開いて下さい。
+- `config.yml` ファイルを開き、鉛筆マークの「Edit this file」をクリックして下さい。
+- `name:` の値を新しい名称に変更して下さい。
+
+例）「福祉会館・社会福祉協議会」→「社会福祉協議会」に変更する場合：
+
+変更前：
+```yaml
+category: welfare_hall
+name: 福祉会館・社会福祉協議会
+filename: 0054.xlsx
+description: ''
+dataType: location
+```
+
+変更後：
+```yaml
+category: welfare_hall
+name: 社会福祉協議会
+filename: 0054.xlsx
+description: ''
+dataType: location
+```
+
+- `「Create new branch for this commit and start a pull request」` にチェックを入れ、`「Propose changes」` をクリックして下さい。
+
+### 2. README.md を編集
+
+- 同じブランチ上で、[README.md](https://github.com/takamatsu-city/opendata/blob/main/README.md) を開いて下さい。
+- 鉛筆マークの「Edit this file」をクリックし、該当データの表示名を同じように変更して下さい。
+- 編集中のブランチ名が手順1で作成したブランチと同じであることを確認し、「Commit changes」をクリックして下さい。
+
+### 3. Pull Request を作成
+
+- 手順1で自動作成された Pull Request のページを開き、内容を確認して下さい。
+- Geolonia にてレビュー・マージを行います。
+
+## データの削除方法
+
+データの削除は手順がやや複雑なため、**Geolonia（smartcity-support@geolonia.com）へご連絡ください**。以下の情報をお伝えいただければ対応いたします。
+
+- 削除したいデータ名（例：市立病院(0052)）
+
+### （参考）削除時に必要な作業
+
+削除の際は、以下の変更を Pull Request で行います。
+
+1. `data/<ディレクトリ名>/` 内のファイルをすべて削除（`config.yml`、データファイル等）
+2. `README.md` から該当データの行を削除


### PR DESCRIPTION
## Summary

作業説明書（INSTRUCTION.md）に、以下の2セクションを追記しました。

- **データ名称の変更方法**: `config.yml` の `name:` と `README.md` を編集する手順
- **データの削除方法**: Geolonia への依頼を案内 + 参考として削除時の作業内容を記載

## 背景

[geolonia/takamatsu-ops-2026#16](https://github.com/geolonia/takamatsu-ops-2026/issues/16) にて、高松市デジタル戦略課より「データの削除方法」「名称変更の方法」について問い合わせがありました。既存の INSTRUCTION.md には「新規データの追加方法」のみ記載されており、削除・名称変更の手順が不足していたため追記します。

## 方針

- **名称変更**: 市職員がGitHub Web UI上で対応可能なため、具体的な手順を記載
- **削除**: ディレクトリごとの削除がWeb UIでは煩雑なため、Geolonia への連絡を案内し、参考情報として作業内容を併記

## 関連PR

- https://github.com/takamatsu-city/opendata/pull/1353 （市立病院 削除）
- https://github.com/takamatsu-city/opendata/pull/1354 （福祉会館 名称変更）